### PR TITLE
Change Encoder syntax in CirceEx to follow the rest of the repo

### DIFF
--- a/src/main/scala/com/reagroup/exercises/circe/CirceExercises.scala
+++ b/src/main/scala/com/reagroup/exercises/circe/CirceExercises.scala
@@ -71,7 +71,7 @@ object CirceExercises {
       * - https://typelevel.org/cats/typeclasses.html
       * - https://www.parsonsmatt.org/2017/01/07/how_do_type_classes_differ_from_interfaces.html
       */
-    implicit val personEncoder: Encoder[Person] = (p: Person) => {
+    implicit val personEncoder: Encoder[Person] = Encoder { (p: Person) =>
       ???
     }
 
@@ -80,7 +80,7 @@ object CirceExercises {
       *
       * Why can't we define this as implicit as well? How would Scala know which one to pick?
       */
-    val differentPersonEncoder: Encoder[Person] = (p: Person) => {
+    val differentPersonEncoder: Encoder[Person] = Encoder { (p: Person) =>
       Json.obj(
         "different_name" -> p.name.asJson,
         "different_age" -> p.age.asJson


### PR DESCRIPTION
The pre-filled Encoders throughout this repo uses the following syntax:

```scala
  implicit val encoder: Encoder[MovieId] =
    Encoder { movieId =>
      Json.obj(("id", movieId.value.asJson))
    }
```

See:

https://github.com/zendesk/applied-scala/blob/162dce308edd0430f2a66cbfce3d45a472f77487/src/main/scala/com/reagroup/appliedscala/models/MovieId.scala#L25