### PR TITLE
Add test for Http4sMetascoreRepository

### DIFF
--- a/src/main/scala/com/reagroup/appliedscala/urls/fetchenrichedmovie/README.md
+++ b/src/main/scala/com/reagroup/appliedscala/urls/fetchenrichedmovie/README.md
@@ -37,6 +37,8 @@ Hint: We want to start by converting the `String` in the response body into a `M
 
 _**Complete exercise**_
 
+_**Run unit test: `Http4sMetascoreRepositorySpec`**_
+
 ### 4. `FetchEnrichedMovieService` (exercise)
 
 Moving on to the `Service`, we can see it has access to _two_ functions. The first one is to fetch a `Movie` and the second is to fetch a `Metascore`. More concretely, the first is the Postgresql database call and the second one is the OMDB API call.

--- a/src/test/scala/com/reagroup/appliedscala/urls/repositories/Http4sMetascoreRepositorySpec.scala
+++ b/src/test/scala/com/reagroup/appliedscala/urls/repositories/Http4sMetascoreRepositorySpec.scala
@@ -1,19 +1,15 @@
 package com.reagroup.appliedscala.urls.repositories
 
 import org.specs2.mutable.Specification
-import cats.data.IdT
 import cats.effect.IO
 import cats.effect.kernel.Resource
 import io.circe.Json
 import io.circe.syntax._
-import org.http4s._
 import org.http4s.circe.CirceEntityEncoder._
-import org.http4s.implicits._
 import org.http4s.client.Client
-import org.http4s.dsl.{Http4sDsl, Http4sDsl2}
+import org.http4s.dsl.Http4sDsl
 import cats.effect.unsafe.implicits.global
 import com.reagroup.appliedscala.urls.fetchenrichedmovie.Metascore
-import cats.syntax.all._
 
 final class Http4sMetascoreRepositorySpec extends Specification with Http4sDsl[IO] {
   

--- a/src/test/scala/com/reagroup/appliedscala/urls/repositories/Http4sMetascoreRepositorySpec.scala
+++ b/src/test/scala/com/reagroup/appliedscala/urls/repositories/Http4sMetascoreRepositorySpec.scala
@@ -1,0 +1,48 @@
+package com.reagroup.appliedscala.urls.repositories
+
+import org.specs2.mutable.Specification
+import cats.data.IdT
+import cats.effect.IO
+import cats.effect.kernel.Resource
+import io.circe.Json
+import io.circe.syntax._
+import org.http4s._
+import org.http4s.circe.CirceEntityEncoder._
+import org.http4s.implicits._
+import org.http4s.client.Client
+import org.http4s.dsl.{Http4sDsl, Http4sDsl2}
+import cats.effect.unsafe.implicits.global
+import com.reagroup.appliedscala.urls.fetchenrichedmovie.Metascore
+import cats.syntax.all._
+
+final class Http4sMetascoreRepositorySpec extends Specification with Http4sDsl[IO] {
+  
+  "Http4sMetascoreRepository" should {
+
+    val validJson = Json.obj("name" -> "Encanto".asJson, "Metascore" -> 91.asJson)
+    val client = stubClient(validJson)
+    val apiKey = "Some api key"
+    val repo = new Http4sMetascoreRepository(client, apiKey)
+
+    "return Some if the metascore for the movie exists" in {
+      val actual = repo("Encanto")
+      actual.unsafeRunSync() must beSome(Metascore(91))
+
+    }
+
+    "return None if the metascore for the movie does not exist" in {
+      val invalidJson = Json.obj("name" -> "Shark Tale".asJson)
+      val client = stubClient(invalidJson)
+      val apiKey = "Some api key"
+      val repo = new Http4sMetascoreRepository(client, apiKey)
+      val actual = repo("Shark Tale")
+
+      actual.unsafeRunSync() must beNone
+    }
+  }
+
+  private def stubClient(responseJson: Json): Client[IO] = {
+    Client[IO](_ => Resource.make(Ok(responseJson))(_ => IO.unit))
+  }
+
+}


### PR DESCRIPTION
I think having a unit test for the decoding of Http4sMetascoreRepository would help with the exercise.

![](https://media.giphy.com/media/C4FJx9w0hVlt8tVmBF/giphy.gif)